### PR TITLE
Export plugin path in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,11 @@
   <run_depend>roscpp</run_depend>
   <run_depend>gazebo</run_depend>
   <run_depend>gazebo_msgs</run_depend>
+  <run_depend>gazebo_ros</run_depend>
+
+  <export>
+    <gazebo_ros plugin_path="${prefix}/../../build/storm_gazebo_magnet"/>
+  </export>
 
 </package>
 


### PR DESCRIPTION
Dodao sam exportanje plugin_patha u package.xml tako da plugin radi out-of-the-box. Inače treba dodati liniju za exportanje u .bashrc što samo komplicira stvari i često se zaboravi pa magent ne radi iako nema nikakvih grešaka.